### PR TITLE
Use general hash for nodeid

### DIFF
--- a/ISY/IsyNodeClass.py
+++ b/ISY/IsyNodeClass.py
@@ -40,6 +40,7 @@ __author__ = 'Peter Shipley <peter.shipley@gmail.com>'
 __copyright__ = "Copyright (C) 2013 Peter Shipley"
 __license__ = "BSD"
 
+import hashlib
 from ISY.IsyUtilClass import IsySubClass, val2bool 
 from ISY.IsyExceptionClass import *
 # from IsyClass import *
@@ -194,18 +195,6 @@ class _IsyNodeBase(IsySubClass):
 #		self[k] = v
 
 
-
-#
-# convers a node Id  to a int
-# eg: "9 4A 5F 2" => 00001001010010100101111100000010 => 155868930
-#
-def node_id_to_int(h) :
-    a = h.split(' ')
-    return  ( int(a[0], 16) << 24 ) | ( int(a[1], 16) << 16 ) | \
-		    ( int(a[2], 16) << 8 ) | int(a[3], 16)
-
-
-
 # def rate
 # def onlevel
 class IsyNode(_IsyNodeBase):
@@ -258,7 +247,7 @@ class IsyNode(_IsyNodeBase):
 #            if "node-flag" in self._mydict :
 #                self.update()
 
-	self._hash = node_id_to_int(self._mydict["address"])
+	self._hash = hashlib.sha256(self._mydict["address"])
 
         if self.debug & 0x01 :
             print("Init Node : \"" + self._mydict["address"] + \


### PR DESCRIPTION
Aeon Labs Z-Wave smart switch has nodeid of the form ZW002_1, ZW002_143

Fixes exceptions of the form

```
% python isy_nodes.py
Node Name                   Address	Status      Enabled
---------                   -------	------      ------
Traceback (most recent call last):
  File "isy_nodes.py", line 34, in <module>
    list_nodes(myisy)
  File "isy_nodes.py", line 22, in list_nodes
    for nod in isy:
  File "/usr/local/lib/python2.7/dist-packages/ISYlib-0.1.20140704-py2.7.egg/ISY/_isynode.py", line 763, in node_iter
    yield self.get_node(n)
  File "/usr/local/lib/python2.7/dist-packages/ISYlib-0.1.20140704-py2.7.egg/ISY/_isynode.py", line 393, in get_node
    self.nodeCdict[nodeid] = IsyNode(self, self._nodedict[nodeid])
  File "/usr/local/lib/python2.7/dist-packages/ISYlib-0.1.20140704-py2.7.egg/ISY/IsyNodeClass.py", line 261, in __init__
    self._hash = node_id_to_int(self._mydict["address"])
  File "/usr/local/lib/python2.7/dist-packages/ISYlib-0.1.20140704-py2.7.egg/ISY/IsyNodeClass.py", line 205, in node_id_to_int
    ( int(a[2], 16) << 8 ) | int(a[3], 16)
ValueError: invalid literal for int() with base 16: 'ZW002_1'
__del__  <IsyNode ZW002_1 @ isy at 0x7fc8574cd790>
__del__  <Isy isy at 0x7fc85825ebd0>
```