### PR TITLE
Handle ISY version 5+ firmware events.

### DIFF
--- a/ISY/IsyEvent.py
+++ b/ISY/IsyEvent.py
@@ -262,16 +262,18 @@ class ISYEvent(object) :
                     if type(d[child.tag]) != list :
                         t = d[child.tag]
                         d[child.tag] = [t]
-                if list(child) or child.attrib :
+				if list(child) :
                     if child.tag in d :
                         d[child.tag].append(self.et2d(child))
                     else :
                         d[child.tag] = self.et2d(child)
-                else :
+				if child.text :
                     if child.tag in d :
                         d[child.tag].append(child.text)
                     else :
                         d[child.tag] = child.text
+				else :
+					d[child.tag] = ""
         return d
 
 


### PR DESCRIPTION
ISY version 5+ firmware adds some additional information to the
events that are sent through the subscripton channel. Specifically
the <action> tag now includes attributes that specify the unit of measure
and precision of the action value.

Prior to version 5, the action tag would look like:

`<action>255</action>`

Version 5+ firmware will now send:

`<action uom="100" prec="0">255</action>`

The et2d function is not able to parse this change and results in
setting the action key in the dictionary to the attribute list instead
of the value.

This change makes all the dictionary tag name keys get the value or value
list and restricts the attributes to tag_name-attribute_name keys.